### PR TITLE
Add Jest test for Home page

### DIFF
--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import Home from '../src/app/page';
+
+describe('Home page', () => {
+  it('renders Korean dashboard text', () => {
+    render(<Home />);
+    expect(screen.getByText('대시보드!!')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -25,6 +26,12 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.0",
+    "ts-jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add jest and testing-library dev dependencies
- configure Jest with ts-jest and jsdom
- create a basic Home page test rendering `대시보드!!`
- add `test` script to package.json

## Testing
- `npm test` *(fails: jest not found)*